### PR TITLE
Reuse same AntUsbDevice for same UsbDevice instance

### DIFF
--- a/src/main/java/be/glever/ant/usb/AntUsbDevice.java
+++ b/src/main/java/be/glever/ant/usb/AntUsbDevice.java
@@ -58,6 +58,10 @@ public class AntUsbDevice implements Closeable {
         this.device = device;
     }
 
+    public UsbDevice getUsbDevice() {
+        return device;
+    }
+
 
     private static Publisher<AntMessage> mapToErrorIfRequired(AntMessage antMessage) {
         LOG.debug(() -> format("in flux, received message %s", antMessage));

--- a/src/main/java/be/glever/ant/usb/AntUsbDevice.java
+++ b/src/main/java/be/glever/ant/usb/AntUsbDevice.java
@@ -51,6 +51,8 @@ public class AntUsbDevice implements Closeable {
     private AntUsbWriter antUsbWriter;
     private AntChannel[] antChannels;
 
+    private boolean isInitialized = false;
+
 
     public AntUsbDevice(UsbDevice device) {
         this.device = device;
@@ -73,19 +75,27 @@ public class AntUsbDevice implements Closeable {
     }
 
     public void initialize() throws AntException {
+        if (isInitialized)
+            return;
 
         try {
             initUsbInterface();
             initAntDevice();
+            isInitialized = true;
         } catch (Exception e) {
             throw new AntException(e);
         }
+    }
+
+    public boolean isInitialized() {
+        return isInitialized;
     }
 
     @Override
     public void close() throws IOException {
         try {
             resetUsbDevice();
+            isInitialized = false;
         } catch (Exception e) {
             LOG.error(() -> "Reset ant stick failed. Continuing with shutdown of usb interface.", e);
         }
@@ -96,6 +106,7 @@ public class AntUsbDevice implements Closeable {
             if (activeUsbInterface.isClaimed()) {
                 activeUsbInterface.release();
             }
+            isInitialized = false;
         } catch (Exception e) {
             throw new IOException(e.getMessage(), e);
         }

--- a/src/main/java/be/glever/ant/usb/AntUsbDeviceFactory.java
+++ b/src/main/java/be/glever/ant/usb/AntUsbDeviceFactory.java
@@ -15,6 +15,11 @@ public class AntUsbDeviceFactory {
     private static final int VENDOR_DYNASTREAM = 0x0fcf;
 
     /**
+     * Keep track of AntUsbDevices, so that the same instance is reused for the same UsbDevice
+     */
+    private static List<AntUsbDevice> antUsbDevices = new ArrayList<>();
+
+    /**
      * Returns a list of <b>uninitialized</b> {@link AntUsbDevice}s that are found on the system.
      *
      * @return
@@ -40,10 +45,26 @@ public class AntUsbDeviceFactory {
                 resultList.addAll(findDevices((UsbHub) device, vendorId, productId));
             } else {
                 if (device.getUsbDeviceDescriptor().idVendor() == vendorId && device.getUsbDeviceDescriptor().idProduct() == productId) {
-                    resultList.add(new AntUsbDevice(device));
+                    resultList.add(resuseOrCreateAntUsbDevice(device));
                 }
             }
         });
         return resultList;
+    }
+
+    private static AntUsbDevice resuseOrCreateAntUsbDevice(UsbDevice device) {
+        AntUsbDevice foundDevice = null;
+
+        for (AntUsbDevice antDev : antUsbDevices) {
+            if (antDev.getUsbDevice() == device)
+                foundDevice = antDev;
+        }
+
+        if (foundDevice == null) {
+            foundDevice = new AntUsbDevice(device);
+            antUsbDevices.add(foundDevice);
+        }
+
+        return foundDevice;
     }
 }


### PR DESCRIPTION
Since an `AntUsbDevice` cannot be initialized multiple times, we have to keep track of whether it is initialized. This however, is only possible, if the same `UsbDevice` always yields the same `AntUsbDevice`.