### PR TITLE
Remove toString from EquipmentType and HeartRateDataSource

### DIFF
--- a/src/main/java/be/glever/antplus/fec/EquipmentType.java
+++ b/src/main/java/be/glever/antplus/fec/EquipmentType.java
@@ -26,24 +26,4 @@ public enum EquipmentType {
     public byte value() {
         return value;
     }
-
-    @Override
-    public String toString() {
-        switch (this) {
-            case Treadmill:
-                return "Treadmill";
-            case Elliptical:
-                return "Elliptical";
-            case Rower:
-                return "Rower";
-            case Climber:
-                return "Climber";
-            case NordicSkier:
-                return "Nordic Skier";
-            case StationaryBike:
-                return "Stationary bike";
-            default:
-                throw new IllegalArgumentException();
-        }
-    }
 }

--- a/src/main/java/be/glever/antplus/fec/HeartRateDataSource.java
+++ b/src/main/java/be/glever/antplus/fec/HeartRateDataSource.java
@@ -3,16 +3,23 @@ package be.glever.antplus.fec;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * Where the FE-C equipment obtains the heart rate measurement from
+ */
 public enum HeartRateDataSource {
+    // Unknown source
     UNKNOWN((byte) 0),
+    // ANT+ sensor connected to the FE-C equipment
     ANT_PLUS((byte) 1),
+    // 5 kHz wireless HRM worn by the athlete
     EM((byte) 3),
+    // Hand contact sensor on the FE-C equipment
     HAND_CONTACTS((byte) 3);
 
     private byte value;
 
-    HeartRateDataSource(byte i) {
-        value = i;
+    HeartRateDataSource(byte value) {
+        this.value = value;
     }
 
     public static Optional<HeartRateDataSource> valueOf(int value) {
@@ -23,21 +30,5 @@ public enum HeartRateDataSource {
 
     public byte value() {
         return value;
-    }
-
-    @Override
-    public String toString() {
-        switch (this) {
-            case UNKNOWN:
-                return "Unknown";
-            case ANT_PLUS:
-                return "ANT+";
-            case EM:
-                return "EM (5 kHz)";
-            case HAND_CONTACTS:
-                return "Hand contact sensors";
-            default:
-                throw new IllegalArgumentException();
-        }
     }
 }


### PR DESCRIPTION
A consumer of this library would probably implement their own human
readable strings, especially if they do internationalization.
New doc comments describe what the values mean.