### PR TITLE
Handled 6 byte capability response

### DIFF
--- a/src/main/java/be/glever/ant/message/requestedresponse/CapabilitiesResponseMessage.java
+++ b/src/main/java/be/glever/ant/message/requestedresponse/CapabilitiesResponseMessage.java
@@ -27,9 +27,9 @@ public class CapabilitiesResponseMessage extends AbstractAntMessage {
 
     @Override
     public void setMessageBytes(byte[] messageContentBytes) throws AntException {
-        if (messageContentBytes.length != 8) {
+        if (messageContentBytes.length < 6 || messageContentBytes.length > 8) {
             throw new AntException(
-                    String.format("Incorrect message length. Given: %s, expected: 8", messageContentBytes.length));
+                    String.format("Incorrect message length. Given: %s, expected: 6-8", messageContentBytes.length));
         }
         this.messageBytes = messageContentBytes;
     }
@@ -135,7 +135,7 @@ public class CapabilitiesResponseMessage extends AbstractAntMessage {
     }
 
     private byte getAdvancedOptions3Byte() {
-        return messageBytes[6];
+        return messageBytes.length > 6 ? messageBytes[6] : 0;
     }
 
     public boolean getAdvancedBurstEnabled() {
@@ -167,7 +167,7 @@ public class CapabilitiesResponseMessage extends AbstractAntMessage {
     }
 
     private byte getAdvancedOptions4Byte() {
-        return messageBytes[7];
+        return messageBytes.length > 7 ? messageBytes[7] : 0;
     }
 
     public boolean getRfActiveNotificationEnabled() {

--- a/src/main/java/be/glever/ant/usb/AntUsbDevice.java
+++ b/src/main/java/be/glever/ant/usb/AntUsbDevice.java
@@ -23,6 +23,7 @@ import reactor.core.scheduler.Schedulers;
 import javax.usb.*;
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -279,7 +280,7 @@ public class AntUsbDevice implements Closeable {
         this.serialNumber = serialNumberMessage.getSerialNumber();
 
         LOG.debug(() -> format("Capabilities: %s", this.capabilities.toString()));
-        LOG.debug(() -> format("Ant Version: %s", ByteUtils.hexString(this.antVersion)));
+        LOG.debug(() -> format("Ant Version: %s", new String(this.antVersion, StandardCharsets.US_ASCII)));
         LOG.debug(() -> format("SerialNumber: %s", ByteUtils.hexString(this.serialNumber)));
     }
 


### PR DESCRIPTION
Assumes no advanced options 3/4 are supported when only 6 bytes
capability response given.

Also logged ANT version in human readable form.

Required this change to get my Wahoo Tickr working with a generic Ant+ USB stick.